### PR TITLE
Switch from squeue to sacct command

### DIFF
--- a/desipipe/provider.py
+++ b/desipipe/provider.py
@@ -383,7 +383,7 @@ class SlurmProvider(BaseProvider):
                     jobid = line.split()[0].strip()
                     if 'RUNNING' in states and state == 'RUNNING':
                         jobids.append(jobid)
-                    elif 'PENDING' in states and state in ('PENDING', 'REQUEUED', 'RESIZING', 'REVOKED', 'SUSPENDED'): # https://slurm.schedmd.com/sacct.html#SECTION_JOB-STATE-CODES
+                    elif 'PENDING' in states and state in ('PENDING', 'REQUEUED', 'RESIZING', 'REVOKED', 'SUSPENDED', 'PENDING+', 'REQUEUED+', 'RESIZING+', 'REVOKED+', 'SUSPENDED+'): # https://slurm.schedmd.com/sacct.html#SECTION_JOB-STATE-CODES
                         jobids.append(jobid)
             self._jobids = jobids = [jobid[0] for jobid in self.processes if jobid[0] in jobids]
         if return_nworkers:


### PR DESCRIPTION
Switch from using `sqs`/`squeue` to using `sacct` to get information on running and pending tasks on NERSC. 

`sacct` talks to the Slurm database daemon (slurmdbd) instead of to the control daemon (slurmctld) ; using `sacct` does not require locks such as squeue, so it is both faster and encouraged by NERSC.